### PR TITLE
Added import to fix GLSLError exceptions

### DIFF
--- a/pyspheregl/utils/shader_vbo.py
+++ b/pyspheregl/utils/shader_vbo.py
@@ -1,5 +1,6 @@
 from pyglet.gl import *
 from ctypes import *
+from shader import GLSLError
 import contextlib
 import numpy as np
 import np_vbo


### PR DESCRIPTION
Currently they throw NameError: GLSLError instead of actual exception. 

I'm aware this is a very minor correction. 